### PR TITLE
Update cadastro.html

### DIFF
--- a/Arquivos HTML/cadastro.html
+++ b/Arquivos HTML/cadastro.html
@@ -106,7 +106,8 @@
       // Simula salvamento no localStorage
       const usuario = {
         login: e.target.login.value,
-        senha: senha
+        senha: senha,
+        nome: e.target.nome.value
       };
       localStorage.setItem('usuario', JSON.stringify(usuario));
       alert("Usuário cadastrado com sucesso!");


### PR DESCRIPTION
Resolução de um erro de não redirecionamento de volta para a página de login após o cadastro finalizado, adicionando "nome: e.target.nome.value" que serve para salvar o primeiro nome da pessoa, para aparecer o nome da pessoa na página principal como logado. Essa alteração foi feita pelo mago Jean.